### PR TITLE
Merge commit back into master, fix cam8 crash

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -121,8 +121,4 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch/bumblebee.launch)
   roslaunch_add_file_check(launch/camera.launch)
   roslaunch_add_file_check(launch/stereo.launch)
-
-  # TODO: install in ci I guess
-  #find_package(roslint REQUIRED)
-  #roslint_cpp()
 endif()

--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -8,7 +8,7 @@ set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp roslint nodelet sensor_msgs wfov_camera_msgs
+  roscpp nodelet sensor_msgs wfov_camera_msgs
   image_exposure_msgs camera_info_manager image_transport
   dynamic_reconfigure diagnostic_updater diagnostics_utils)
 find_package(resource_monitor REQUIRED)
@@ -122,6 +122,7 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch/camera.launch)
   roslaunch_add_file_check(launch/stereo.launch)
 
-  find_package(roslint REQUIRED)
-  roslint_cpp()
+  # TODO: install in ci I guess
+  #find_package(roslint REQUIRED)
+  #roslint_cpp()
 endif()

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -221,7 +221,6 @@ private:
     pnh.param<std::string>("frame_id", frame_id_, "camera");
     trace_frame_ = diagnostics_utils::TracePublisher::trace_frame_from_name(frame_id_);
 
-    diagnostics_utils::NodeHealthPublisher::init(&nh, frame_id_);
     diagnostics_utils::TracePublisher::init(&nh);
 
     // Get a serial number through ros

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -312,10 +312,6 @@ private:
       nh.advertise<wfov_camera_msgs::WFOVImage>("image", 1, cb2, cb2))
       
       // image: min_freq 5hz, max max_acceptable sec old
-      ->monitor(min_freq_ * (1.0 - freq_tolerance), 
-                ros::Duration(max_acceptable_delay),
-                diagnostics_utils::DiagnosticLevel::ERROR,
-                window_size)
       ->trace(trace_frame_);
   }
 


### PR DESCRIPTION
Publishing messages during nodelet onInit is (apparently) unsafe and can cause a crash