### PR TITLE
Cam8 Launch Fix

### DIFF
--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -165,10 +165,11 @@ private:
     if (frame_id_ == "cam8")
     {
       ROS_INFO_STREAM("Waiting for cam8 exposure node to finish starting...");
-      const bool ret = ros::service::waitForService("/dynamic_exposure/"+frame_id_+"/ready", 20000); // 20 seconds
+      const bool ret = ros::service::waitForService("/dynamic_exposure/"+frame_id_+"/ready", ros::Duration(20.0)); // 20 seconds
       if (!ret) {
-        ROS_ERROR_STREAM("Timed out waiting for "<<frame_id_<<" exposure node to start. Exiting");
-        return;
+        std::string error_msg = "Timed out waiting for cam8 exposure node to start. Exiting";
+        ROS_ERROR_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
       }
     }
 

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -221,11 +221,11 @@ private:
     pnh.param<std::string>("frame_id", frame_id_, "camera");
 
     // Waiting for exposure node (a prerequisite) to finish being started for cam8
-    if (frame_id == "cam8")
+    if (frame_id_ == "cam8")
     {
-      const bool ret = ros::service::waitForService("/dynamic_exposure/"+frame_id+"/ready", 10000); // 10 seconds
+      const bool ret = ros::service::waitForService("/dynamic_exposure/"+frame_id_+"/ready", 10000); // 10 seconds
       if (!ret) {
-        ROS_ERROR_STREAM("Timed out waiting for "<<frame_id<<" exposure node to start. Exiting");
+        ROS_ERROR_STREAM("Timed out waiting for "<<frame_id_<<" exposure node to start. Exiting");
         return 1;
       }
     }

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -219,6 +219,17 @@ private:
 
     // Get the frame_id, set to 'camera' if not found
     pnh.param<std::string>("frame_id", frame_id_, "camera");
+
+    // Waiting for exposure node (a prerequisite) to finish being started for cam8
+    if (frame_id == "cam8")
+    {
+      const bool ret = ros::service::waitForService("/dynamic_exposure/"+frame_id+"/ready", 10000); // 10 seconds
+      if (!ret) {
+        ROS_ERROR_STREAM("Timed out waiting for "<<frame_id<<" exposure node to start. Exiting");
+        return 1;
+      }
+    }
+    // Start trace frame publisher
     trace_frame_ = diagnostics_utils::TracePublisher::trace_frame_from_name(frame_id_);
 
     diagnostics_utils::TracePublisher::init(&nh);


### PR DESCRIPTION
 **CHANGELOG**
- the theory behind the fix is to hold the cam8 driver from connecting to the camera until the dynamic exposure node is started in order to avoid a race condition. 


**The accompanying change for the busy-wait: https://github.com/embarktrucks/brain/pull/6633**