### PR TITLE
Require C++17 in CMakeLists.txt

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pointgrey_camera_driver)
 
+# We need C++17 in order to use std::clamp
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_program(CCACHE_FOUND ccache)
 if (CCACHE_FOUND)
 set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)


### PR DESCRIPTION
**Require C++17 in CMakelists.txt**

[DEVX-310](https://embarktrucks.atlassian.net/browse/DEVX-310) - Add Clang build profile for Brain

Clang is more strict on what is and isn't supported without asking for C++17, and std::clamp is missing from earlier versions, so we need this to use it in Brain since ROS defaults to an earlier C++ spec (11?).

[DEVX-310]: https://embarktrucks.atlassian.net/browse/DEVX-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ